### PR TITLE
Enable unit production from buildings

### DIFF
--- a/Assets/Scripts/SelectionManager.cs
+++ b/Assets/Scripts/SelectionManager.cs
@@ -11,10 +11,12 @@ public class SelectionManager : MonoBehaviour
     private bool isDragging;
 
     private List<RTSISelectable> selectedObjects = new List<RTSISelectable>();
+    private ToolbarHandler toolbar;
 
     void Awake()
     {
         mainCamera = Camera.main;
+        toolbar = FindObjectOfType<ToolbarHandler>();
     }
 
     void Update()
@@ -49,6 +51,10 @@ public class SelectionManager : MonoBehaviour
             obj.Deselect();
         }
         selectedObjects.Clear();
+        if (toolbar != null)
+        {
+            toolbar.OnDeselect();
+        }
 
         // Single click selection
         if (Vector2.Distance(startPos, endPos) < 10f)
@@ -88,6 +94,18 @@ public class SelectionManager : MonoBehaviour
         foreach (var obj in selectedObjects)
         {
             Debug.Log($"{obj} selected.");
+        }
+
+        if (toolbar != null)
+        {
+            if (selectedObjects.Count == 1 && selectedObjects[0] is RTSBuilding building)
+            {
+                toolbar.OnSelect(building);
+            }
+            else
+            {
+                toolbar.OnDeselect();
+            }
         }
     }
 }

--- a/Assets/Scripts/ToolbarHandler.cs
+++ b/Assets/Scripts/ToolbarHandler.cs
@@ -39,24 +39,35 @@ public class ToolbarHandler : MonoBehaviour
     {
         if (currentSelection != null)
         {
-            // Show the toolbar and update the UI elements with the selected object's data
             toolbarPanel.SetActive(true);
-
-            // Assuming RTSISelectable has a Name property and a method to get stats
             unitNameText.text = currentSelection.BuildingName;
             unitStatsText.text = currentSelection.GetStats();
 
-            // Enable or update action buttons as needed
             for (int i = 0; i < actionButtons.Length; i++)
             {
-                // Assuming actionButtons correspond to actions the unit can take
-                actionButtons[i].SetActive(true); // Show buttons
-                // Set button text or icon based on the currentSelection's available actions
+                if (currentSelection.unitPrefabs != null && i < currentSelection.unitPrefabs.Length)
+                {
+                    actionButtons[i].SetActive(true);
+                    var txt = actionButtons[i].GetComponentInChildren<TextMeshProUGUI>();
+                    if (txt != null)
+                        txt.text = currentSelection.unitPrefabs[i].name;
+
+                    int index = i;
+                    var btn = actionButtons[i].GetComponent<Button>();
+                    if (btn != null)
+                    {
+                        btn.onClick.RemoveAllListeners();
+                        btn.onClick.AddListener(() => currentSelection.BuildUnit(index));
+                    }
+                }
+                else
+                {
+                    actionButtons[i].SetActive(false);
+                }
             }
         }
         else
         {
-            // Hide the toolbar and disable buttons
             toolbarPanel.SetActive(false);
             foreach (var button in actionButtons)
             {

--- a/Assets/Scripts/rtsUnit.cs
+++ b/Assets/Scripts/rtsUnit.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.AI;
 
-public class RTSUnit : MonoBehaviour, RTSISelectable
+public class RTSUnit : GameEntity, RTSISelectable
 {
     private Vector3 m_Position;
     private NavMeshAgent navMeshAgent;
@@ -9,7 +9,11 @@ public class RTSUnit : MonoBehaviour, RTSISelectable
     Vector3 RTSISelectable.Position
     {
         get => m_Position;
-        set => m_Position = value;
+        set
+        {
+            m_Position = value;
+            position = value;
+        }
     }
 
     private void Start()
@@ -37,7 +41,14 @@ public class RTSUnit : MonoBehaviour, RTSISelectable
     public void Spawn(Vector3 spawnPosition, float checkRadius)
     {
         m_Position = AdjustPositionIfCollides(spawnPosition, checkRadius);
+        position = m_Position;
         transform.position = m_Position;
+    }
+
+    public void Spawn(Vector3 spawnPosition, float checkRadius, Vector3 rallyPoint)
+    {
+        Spawn(spawnPosition, checkRadius);
+        MoveToPosition(rallyPoint);
     }
 
     private Vector3 AdjustPositionIfCollides(Vector3 position, float radius)
@@ -69,5 +80,10 @@ public class RTSUnit : MonoBehaviour, RTSISelectable
         {
             navMeshAgent.SetDestination(position);
         }
+    }
+
+    public string GetStats()
+    {
+        return $"HP: {health}\nArmor: {armor}";
     }
 }


### PR DESCRIPTION
## Summary
- extend `rtsBuilding` with unit spawning support and rally points
- allow units to spawn with rally destinations
- update toolbar to show buildable units and hook actions
- notify toolbar about selection changes
- derive `rtsUnit` and `rtsBuilding` from `GameEntity` for basic stats

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68701a7b28d48322ada7f1e456d5bf58