### PR TITLE
Dynamic toolbar spawns

### DIFF
--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -5,14 +5,38 @@ using UnityEngine;
 
 public class Spawner : MonoBehaviour
 {
-    public GameObject HQPrefab;
+    // List of available building prefabs that can be spawned from the toolbar
+    public List<GameObject> buildingPrefabs = new List<GameObject>();
+
+    // Optional list of units that can be spawned. Currently used when a
+    // building is selected and the toolbar generates unit buttons.
+    public List<GameObject> unitPrefabs = new List<GameObject>();
+
+    // Parent object under which spawned objects will be organised.  This can be
+    // left null in which case the objects will be created at the root of the
+    // scene.
     public GameObject PlayerObjects;
-    public void SpawnHQ()
+
+    /// <summary>
+    /// Spawn a building from <see cref="buildingPrefabs"/> by index.
+    /// </summary>
+    /// <param name="index">Index of the building prefab.</param>
+    public void SpawnBuilding(int index)
     {
-        var spawn  = Instantiate(HQPrefab);
+        if (index < 0 || index >= buildingPrefabs.Count)
+            return;
+
+        var prefab = buildingPrefabs[index];
+        var parent = PlayerObjects != null ? PlayerObjects.transform : null;
+        var spawn = Instantiate(prefab, parent);
         spawn.transform.localScale = Vector3.one;
         spawn.transform.localPosition = Vector3.one;
         spawn.transform.position = Vector3.one;
-        spawn.GetComponent<RTSBuilding>().PrebuildHighlight();
+
+        var building = spawn.GetComponent<RTSBuilding>();
+        if (building != null)
+        {
+            building.PrebuildHighlight();
+        }
     }
 }

--- a/Assets/Scripts/ToolbarHandler.cs
+++ b/Assets/Scripts/ToolbarHandler.cs
@@ -9,13 +9,27 @@ public class ToolbarHandler : MonoBehaviour
     public GameObject toolbarPanel;
     public TextMeshProUGUI unitNameText;
     public TextMeshProUGUI unitStatsText;
-    public GameObject[] actionButtons;
+
+    // Prefab used for dynamically creating buttons in the toolbar
+    public GameObject buttonPrefab;
+
+    // Parent transform for the generated buttons.  If left null the toolbar
+    // panel transform will be used.
+    public Transform buttonParent;
+
+    // Spacing between the created buttons.  Layout groups in the UI can also be
+    // used instead of this value.
+    public float buttonSpacing = 100f;
 
     private RTSBuilding currentSelection;
 
+    private Spawner spawner;
+    private readonly List<GameObject> spawnedButtons = new List<GameObject>();
+
     void Start()
     {
-        toolbarPanel.SetActive(false); // Hide the toolbar at start
+        spawner = FindObjectOfType<Spawner>();
+        UpdateToolbar();
     }
 
     void Update()
@@ -37,42 +51,81 @@ public class ToolbarHandler : MonoBehaviour
 
     private void UpdateToolbar()
     {
+        // Remove any existing dynamic buttons
+        foreach (var button in spawnedButtons)
+        {
+            if (button != null)
+                Destroy(button);
+        }
+        spawnedButtons.Clear();
+
+        Transform parent = buttonParent != null ? buttonParent : toolbarPanel.transform;
+
         if (currentSelection != null)
         {
+            // Display information about the selected building
             toolbarPanel.SetActive(true);
             unitNameText.text = currentSelection.BuildingName;
             unitStatsText.text = currentSelection.GetStats();
 
-            for (int i = 0; i < actionButtons.Length; i++)
+            if (currentSelection.unitPrefabs != null)
             {
-                if (currentSelection.unitPrefabs != null && i < currentSelection.unitPrefabs.Length)
+                for (int i = 0; i < currentSelection.unitPrefabs.Length; i++)
                 {
-                    actionButtons[i].SetActive(true);
-                    var txt = actionButtons[i].GetComponentInChildren<TextMeshProUGUI>();
+                    int idx = i;
+                    GameObject buttonObj = Instantiate(buttonPrefab, parent);
+                    PositionButton(buttonObj.GetComponent<RectTransform>(), idx);
+
+                    var txt = buttonObj.GetComponentInChildren<TextMeshProUGUI>();
                     if (txt != null)
                         txt.text = currentSelection.unitPrefabs[i].name;
 
-                    int index = i;
-                    var btn = actionButtons[i].GetComponent<Button>();
+                    var btn = buttonObj.GetComponent<Button>();
                     if (btn != null)
                     {
-                        btn.onClick.RemoveAllListeners();
-                        btn.onClick.AddListener(() => currentSelection.BuildUnit(index));
+                        btn.onClick.AddListener(() => currentSelection.BuildUnit(idx));
                     }
-                }
-                else
-                {
-                    actionButtons[i].SetActive(false);
+
+                    spawnedButtons.Add(buttonObj);
                 }
             }
         }
         else
         {
-            toolbarPanel.SetActive(false);
-            foreach (var button in actionButtons)
+            // Nothing selected: show building spawn buttons
+            toolbarPanel.SetActive(true);
+            unitNameText.text = string.Empty;
+            unitStatsText.text = string.Empty;
+
+            if (spawner != null)
             {
-                button.SetActive(false);
+                for (int i = 0; i < spawner.buildingPrefabs.Count; i++)
+                {
+                    int idx = i;
+                    GameObject buttonObj = Instantiate(buttonPrefab, parent);
+                    PositionButton(buttonObj.GetComponent<RectTransform>(), idx);
+
+                    var txt = buttonObj.GetComponentInChildren<TextMeshProUGUI>();
+                    if (txt != null)
+                        txt.text = spawner.buildingPrefabs[i].name;
+
+                    var btn = buttonObj.GetComponent<Button>();
+                    if (btn != null)
+                    {
+                        btn.onClick.AddListener(() => spawner.SpawnBuilding(idx));
+                    }
+
+                    spawnedButtons.Add(buttonObj);
+                }
             }
         }
+    }
+
+    private void PositionButton(RectTransform rect, int index)
+    {
+        if (rect == null)
+            return;
+
+        rect.anchoredPosition = new Vector2(index * buttonSpacing, rect.anchoredPosition.y);
     }
 }


### PR DESCRIPTION
## Summary
- allow `Spawner` to hold building/unit prefab lists and spawn buildings by index
- rework `ToolbarHandler` so it dynamically creates buttons
  - when nothing is selected it shows building spawn buttons
  - when a building is selected it shows that building's available units

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68701f7d520483229dad4b463ee75dd1