### PR TITLE
Dynamic toolbar spawns

### DIFF
--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -5,14 +5,38 @@ using UnityEngine;
 
 public class Spawner : MonoBehaviour
 {
-    public GameObject HQPrefab;
+    // List of available building prefabs that can be spawned from the toolbar
+    public List<GameObject> buildingPrefabs = new List<GameObject>();
+
+    // Optional list of units that can be spawned. Currently used when a
+    // building is selected and the toolbar generates unit buttons.
+    public List<GameObject> unitPrefabs = new List<GameObject>();
+
+    // Parent object under which spawned objects will be organised.  This can be
+    // left null in which case the objects will be created at the root of the
+    // scene.
     public GameObject PlayerObjects;
-    public void SpawnHQ()
+
+    /// <summary>
+    /// Spawn a building from <see cref="buildingPrefabs"/> by index.
+    /// </summary>
+    /// <param name="index">Index of the building prefab.</param>
+    public void SpawnBuilding(int index)
     {
-        var spawn  = Instantiate(HQPrefab);
+        if (index < 0 || index >= buildingPrefabs.Count)
+            return;
+
+        var prefab = buildingPrefabs[index];
+        var parent = PlayerObjects != null ? PlayerObjects.transform : null;
+        var spawn = Instantiate(prefab, parent);
         spawn.transform.localScale = Vector3.one;
         spawn.transform.localPosition = Vector3.one;
         spawn.transform.position = Vector3.one;
-        spawn.GetComponent<RTSBuilding>().PrebuildHighlight();
+
+        var building = spawn.GetComponent<RTSBuilding>();
+        if (building != null)
+        {
+            building.PrebuildHighlight();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow `Spawner` to hold building/unit prefab lists and spawn buildings by index
- rework `ToolbarHandler` so it dynamically creates buttons
  - when nothing is selected it shows building spawn buttons
  - when a building is selected it shows that building's available units
- fix button listeners and align buttons using prefab size and spacing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68701f7d520483229dad4b463ee75dd1