### PR TITLE
Implement entity size and placement checks

### DIFF
--- a/Assets/Scripts/Entities/GameEntity.cs
+++ b/Assets/Scripts/Entities/GameEntity.cs
@@ -33,6 +33,7 @@ public class GameEntity : MonoBehaviour
     // Size settings for placement and collision
     public SizeCategory sizeCategory = SizeCategory.Small;
     public float sizeRadius;
+    public float placementRadius;
 }
 public enum GameResource
 {

--- a/Assets/Scripts/Entities/GameEntity.cs
+++ b/Assets/Scripts/Entities/GameEntity.cs
@@ -29,6 +29,10 @@ public class GameEntity : MonoBehaviour
     public bool isResource;
     public GameResource resourceType;
     public float resourceAmount;
+
+    // Size settings for placement and collision
+    public SizeCategory sizeCategory = SizeCategory.Small;
+    public float sizeRadius;
 }
 public enum GameResource
 {

--- a/Assets/Scripts/Entities/rtsBuilding.cs
+++ b/Assets/Scripts/Entities/rtsBuilding.cs
@@ -23,6 +23,7 @@ public class RTSBuilding : GameEntity, RTSISelectable
     private void Awake()
     {
         toolbar = FindObjectOfType<ToolbarHandler>();
+        sizeRadius = PlacementHelper.GetBoundingRadius(gameObject);
     }
 
     public string GetStats()
@@ -58,13 +59,20 @@ public class RTSBuilding : GameEntity, RTSISelectable
             }
             if (Input.GetMouseButtonDown(0)) // Left-click to place
             {
-                BuildOverlayObject.SetActive(false);
-                ActivateObject.SetActive(false);
-                BuildObject.SetActive(true);
-                DeactiveObject.SetActive(false);
-                SelectRing.SetActive(false);
-                StartCoroutine(BuildProgressCoroutine());
-                yield break;
+                if (PlacementHelper.CanPlace(this, transform.position))
+                {
+                    BuildOverlayObject.SetActive(false);
+                    ActivateObject.SetActive(false);
+                    BuildObject.SetActive(true);
+                    DeactiveObject.SetActive(false);
+                    SelectRing.SetActive(false);
+                    StartCoroutine(BuildProgressCoroutine());
+                    yield break;
+                }
+                else
+                {
+                    Debug.Log("Invalid placement location.");
+                }
             }
             else if (Input.GetMouseButtonDown(1) || Input.GetKeyDown(KeyCode.Escape)) // Right-click or Esc to cancel
             {
@@ -111,7 +119,15 @@ public class RTSBuilding : GameEntity, RTSISelectable
         RTSUnit unit = unitObj.GetComponent<RTSUnit>();
         if (unit != null)
         {
-            unit.Spawn(spawnPos, 1f, rally);
+            if (PlacementHelper.CanPlace(unit, spawnPos))
+            {
+                unit.Spawn(spawnPos, 1f, rally);
+            }
+            else
+            {
+                Debug.Log("Unit spawn location blocked.");
+                Destroy(unitObj);
+            }
         }
         else
         {

--- a/Assets/Scripts/Entities/rtsBuilding.cs
+++ b/Assets/Scripts/Entities/rtsBuilding.cs
@@ -25,6 +25,8 @@ public class RTSBuilding : GameEntity, RTSISelectable
         toolbar = FindObjectOfType<ToolbarHandler>();
         sizeRadius = PlacementHelper.GetBoundingRadius(gameObject);
         sizeCategory = PlacementHelper.DetermineCategory(sizeRadius);
+        placementRadius = PlacementHelper.GetMaxRadius(sizeCategory);
+        PlacementHelper.EnsureCollider(gameObject, placementRadius);
     }
 
     public string GetStats()
@@ -122,7 +124,7 @@ public class RTSBuilding : GameEntity, RTSISelectable
         {
             if (PlacementHelper.CanPlace(unit, spawnPos))
             {
-                unit.Spawn(spawnPos, 1f, rally);
+                unit.Spawn(spawnPos, unit.placementRadius, rally);
             }
             else
             {

--- a/Assets/Scripts/Entities/rtsBuilding.cs
+++ b/Assets/Scripts/Entities/rtsBuilding.cs
@@ -24,6 +24,7 @@ public class RTSBuilding : GameEntity, RTSISelectable
     {
         toolbar = FindObjectOfType<ToolbarHandler>();
         sizeRadius = PlacementHelper.GetBoundingRadius(gameObject);
+        sizeCategory = PlacementHelper.DetermineCategory(sizeRadius);
     }
 
     public string GetStats()

--- a/Assets/Scripts/Entities/rtsUnit.cs
+++ b/Assets/Scripts/Entities/rtsUnit.cs
@@ -29,6 +29,12 @@ public class RTSUnit : GameEntity, RTSISelectable
         // Calculate size based on attached colliders
         sizeRadius = PlacementHelper.GetBoundingRadius(gameObject);
         sizeCategory = PlacementHelper.DetermineCategory(sizeRadius);
+        placementRadius = PlacementHelper.GetMaxRadius(sizeCategory);
+        PlacementHelper.EnsureCollider(gameObject, placementRadius);
+        if (navMeshAgent != null)
+        {
+            navMeshAgent.radius = placementRadius;
+        }
 
         tracker = GetComponent<GameEntityTrackerItem>();
         if (tracker == null)
@@ -55,7 +61,7 @@ public class RTSUnit : GameEntity, RTSISelectable
 
     public void Spawn(Vector3 spawnPosition, float checkRadius)
     {
-        float radius = PlacementHelper.GetMaxRadius(sizeCategory);
+        float radius = placementRadius;
         if (checkRadius > radius)
             radius = checkRadius;
 

--- a/Assets/Scripts/Entities/rtsUnit.cs
+++ b/Assets/Scripts/Entities/rtsUnit.cs
@@ -28,6 +28,7 @@ public class RTSUnit : GameEntity, RTSISelectable
 
         // Calculate size based on attached colliders
         sizeRadius = PlacementHelper.GetBoundingRadius(gameObject);
+        sizeCategory = PlacementHelper.DetermineCategory(sizeRadius);
 
         tracker = GetComponent<GameEntityTrackerItem>();
         if (tracker == null)
@@ -54,7 +55,7 @@ public class RTSUnit : GameEntity, RTSISelectable
 
     public void Spawn(Vector3 spawnPosition, float checkRadius)
     {
-        float radius = sizeRadius + PlacementHelper.GetSpacing(sizeCategory);
+        float radius = PlacementHelper.GetMaxRadius(sizeCategory);
         if (checkRadius > radius)
             radius = checkRadius;
 

--- a/Assets/Scripts/Utilities/PlacementHelper.cs
+++ b/Assets/Scripts/Utilities/PlacementHelper.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+
+public enum SizeCategory
+{
+    Small,
+    Medium,
+    Large
+}
+
+public static class PlacementHelper
+{
+    public static float GetSpacing(SizeCategory size)
+    {
+        switch (size)
+        {
+            case SizeCategory.Small: return 0.5f;
+            case SizeCategory.Medium: return 1f;
+            case SizeCategory.Large: return 2f;
+            default: return 0.5f;
+        }
+    }
+
+    public static float GetBoundingRadius(GameObject obj)
+    {
+        Collider[] colliders = obj.GetComponentsInChildren<Collider>();
+        if (colliders.Length == 0)
+            return 0.5f;
+        Bounds b = colliders[0].bounds;
+        foreach (var c in colliders)
+            b.Encapsulate(c.bounds);
+        return Mathf.Max(b.extents.x, Mathf.Max(b.extents.y, b.extents.z));
+    }
+
+    public static bool CanPlace(GameEntity entity, Vector3 position)
+    {
+        float radius = entity.sizeRadius + GetSpacing(entity.sizeCategory);
+        Collider[] hits = Physics.OverlapSphere(position, radius, ~0, QueryTriggerInteraction.Ignore);
+        foreach (var hit in hits)
+        {
+            if (hit.transform != entity.transform && !hit.transform.IsChildOf(entity.transform))
+                return false;
+        }
+        return true;
+    }
+}

--- a/Assets/Scripts/Utilities/PlacementHelper.cs
+++ b/Assets/Scripts/Utilities/PlacementHelper.cs
@@ -84,7 +84,7 @@ public static class PlacementHelper
 
     public static bool CanPlace(GameEntity entity, Vector3 position)
     {
-        float radius = GetMaxRadius(entity.sizeCategory);
+        float radius = entity.placementRadius > 0f ? entity.placementRadius : GetMaxRadius(entity.sizeCategory);
         Collider[] hits = Physics.OverlapSphere(position, radius, ~0, QueryTriggerInteraction.Ignore);
         foreach (var hit in hits)
         {
@@ -92,5 +92,17 @@ public static class PlacementHelper
                 return false;
         }
         return true;
+    }
+
+    public static void EnsureCollider(GameObject obj, float radius)
+    {
+        var sphere = obj.GetComponent<SphereCollider>();
+        if (sphere == null)
+        {
+            sphere = obj.AddComponent<SphereCollider>();
+            sphere.center = Vector3.zero;
+        }
+        sphere.radius = radius;
+        sphere.isTrigger = false;
     }
 }


### PR DESCRIPTION
## Summary
- add `PlacementHelper` utility with basic size categories and overlap checks
- store a size category and calculated radius in `GameEntity`
- compute size radius for units and buildings
- validate placement when placing buildings and spawning units

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687038148478832283d25de73e68eea7